### PR TITLE
refactor(sentry): exit process gracefully

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,13 @@ exports.register = (server, options, next) => {
     const client = new Raven.Client(dsn, options.client);
 
     if (options.patchGlobal) {
-        client.patchGlobal();
+        client.patchGlobal((err) => {
+
+            /* $lab:coverage:off$ */
+            console.error(err);
+            process.exit(1);
+            /* $lab:coverage:on$ */
+        });
     }
 
     server.expose('raven', client);

--- a/test/index.js
+++ b/test/index.js
@@ -20,8 +20,16 @@ const internals = {};
 // Test shortcuts
 
 const lab = exports.lab = Lab.script();
-const it = lab.it;
+const afterEach = lab.afterEach;
 const expect = Code.expect;
+const it = lab.it;
+
+
+afterEach((done) => {
+
+    Raven.Client.restore();
+    done();
+});
 
 
 it('registers with the dsn and client options', (done) => {
@@ -34,7 +42,7 @@ it('registers with the dsn and client options', (done) => {
         expect(opts).to.deep.equal('dsn');
 
         return {
-            patchGlobal: (options) => expect(options).to.not.exist()
+            patchGlobal: (cb) => expect(cb).to.be.a.function()
         };
     });
 
@@ -50,7 +58,6 @@ it('registers with the dsn and client options', (done) => {
     server.register(plugins, (err) => {
 
         expect(err).to.not.exist();
-        Raven.Client.restore();
         return done();
     });
 });
@@ -99,7 +106,6 @@ it('captures a request-error', (done) => {
 
         server.inject('/', () => {
 
-            Raven.Client.restore();
             return done();
         });
     });
@@ -141,7 +147,6 @@ it('does not capture Boom errors', (done) => {
 
         server.inject('/boom', () => {
 
-            Raven.Client.restore();
             return done();
         });
     });


### PR DESCRIPTION
Register a callback on Global Error Handler to exit process gracefully with a status code of 1 and log error to console.
