### PR TITLE
fix(globalPatch): prevent global patch on local/qa enviroments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ exports.register = (server, options, next) => {
     const dsn = options.dsn;
     const client = new Raven.Client(dsn, options.client);
 
-    if (options.patchGlobal) {
+    if (dsn && options.patchGlobal) {
         client.patchGlobal((err) => {
 
             /* $lab:coverage:off$ */

--- a/test/index.js
+++ b/test/index.js
@@ -151,3 +151,33 @@ it('does not capture Boom errors', (done) => {
         });
     });
 });
+
+
+it('does not patch global if missing dsn', (done) => {
+
+    const server = new Hapi.Server();
+    server.connection();
+
+    Sinon.stub(Raven, 'Client', (opts) => {
+
+        expect(opts).to.not.exist();
+
+        return {
+            patchGlobal: (cb) => expect(cb).to.not.exist()
+        };
+    });
+
+    const plugins = {
+        register: Plugin,
+        options: {
+            patchGlobal: true,
+            client: Raven
+        }
+    };
+
+    server.register(plugins, (err) => {
+
+        expect(err).to.not.exist();
+        return done();
+    });
+});


### PR DESCRIPTION
- will not patch global (uncaugthExceptions) if both dsn and patchGlobal are not
  set
